### PR TITLE
Refactor StaffChat and implement TeamChatCommand

### DIFF
--- a/src/main/java/de/firstmc/staffchat/StaffChat.java
+++ b/src/main/java/de/firstmc/staffchat/StaffChat.java
@@ -5,24 +5,25 @@ import com.google.inject.Inject;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.proxy.ProxyServer;
+import de.firstmc.staffchat.commands.TeamChatCommand;
+
+import java.util.logging.Logger;
 
 @Plugin(id = "TeamChat", name = "TeamChat", version = "0.1.0-SNAPSHOT",
-        url = "https://firstmc.de", description = "Velocity TeamChat", authors = {"MerryChristmas,ExceptionThread"})
-public record StaffChat(ProxyServer proxyServer) {
-    private static StaffChat instance;
+		url = "https://firstmc.de", description = "Velocity TeamChat", authors = {"MerryChristmas,ExceptionThread"})
+public class StaffChat {
 
-    @Inject
-    public StaffChat {
-        instance = this;
-    }
+	private final ProxyServer proxyServer;
 
-    @Subscribe
-    public void handle(ProxyInitializeEvent event) {
-        this.proxyServer.getCommandManager().register("tc", new TeamChatCommand());
-        this.proxyServer.getCommandManager().register("tc", new StaffChatCommand());
-    }
+	@Inject
+	public StaffChat(ProxyServer proxyServer, Logger logger) {
+		this.proxyServer = proxyServer;
 
-    public static StaffChat getInstance() {
-        return instance;
-    }
+		logger.info("Plugin started successfully.");
+	}
+
+	@Subscribe
+	public void handle(ProxyInitializeEvent event) {
+		this.proxyServer.getCommandManager().register("tc", new TeamChatCommand(proxyServer));
+	}
 }


### PR DESCRIPTION
Refactored StaffChat from a record to a regular class for better control and flexibility. StaffChat constructor now also accepts a Logger instance. TeamChatCommand has been implemented and registered to the ProxyServer's command manager to provide a dedicated chat space for staff.