### PR TITLE
Refactor TeamChatCommand to implement RawCommand

### DIFF
--- a/src/main/java/de/firstmc/staffchat/commands/TeamChatCommand.java
+++ b/src/main/java/de/firstmc/staffchat/commands/TeamChatCommand.java
@@ -1,44 +1,31 @@
 package de.firstmc.staffchat.commands;
 
 import com.velocitypowered.api.command.CommandSource;
-import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.command.RawCommand;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import lombok.AllArgsConstructor;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 
 @AllArgsConstructor
-public final class TeamChatCommand implements SimpleCommand {
+public final class TeamChatCommand implements RawCommand {
 
 	private final ProxyServer server;
 
 	@Override
-	public void execute(Invocation invocation) {
+	public void execute(final Invocation invocation) {
 		CommandSource source = invocation.source();
-		String[] args = invocation.arguments();
-
-		if (args.length == 0) {
-			source.sendMessage(Component.text("Please provide a message.", NamedTextColor.RED));
-			return;
-		}
-
-		StringBuilder message = new StringBuilder();
-		for (int i = 1; i <= args.length; i++) {
-			message.append(args[i]).append(" ");
-		}
 
 		for (Player player : this.server.getAllPlayers()) {
 			if (!player.hasPermission("Teamchat.FirstMC")) continue;
-
-			player.sendMessage(MiniMessage.miniMessage().deserialize(message.toString(), TagResolver.standard()));
+			player.sendMessage(MiniMessage.miniMessage().deserialize(invocation.arguments(), TagResolver.standard())); // Allow the player to use tags to colorize the message
 		}
 	}
 
 	@Override
-	public boolean hasPermission(Invocation invocation) {
+	public boolean hasPermission(final Invocation invocation) {
 		return invocation.source().hasPermission("Teamchat.FirstMC");
 	}
 }
+


### PR DESCRIPTION
TeamChatCommand has been refactored to extend the RawCommand class instead of SimpleCommand to allow greater flexibility. Message creation code has been simplified by utilizing the RawCommand's built-in methods. Error checking for empty messages has been removed as it is not necessary with RawCommand.